### PR TITLE
Password and Username validation

### DIFF
--- a/server/functions/util/validation.js
+++ b/server/functions/util/validation.js
@@ -9,6 +9,17 @@ const isEmpty = (string) => {
     else return false;
 };
 
+const isValidLength = (string, minLength) => {
+    if (string.length >= minLength) return true;
+    else return false;
+}
+
+const hasWhiteSpace = (string) => {
+    const regex = /\s/g;
+    return regex.test(string);
+
+}
+
 exports.validateSignup = (data) => {
     let errors = {};
 
@@ -18,10 +29,13 @@ exports.validateSignup = (data) => {
         errors.email = 'Must be a valid email address';
     }
     if (isEmpty(data.password)) errors.password = 'Must not be empty';
+    if (!isValidLength(data.password, 6)) errors.password = 'Must be at least 6 characters';
     if (data.password !== data.confirmPassword)
         errors.confirmPassword = 'Passwords must match';
 
     if (isEmpty(data.username)) errors.username = 'Must not be empty';
+    if (hasWhiteSpace(data.username)) errors.username = 'Must not contain invalid characters';
+    
     if (isEmpty(data.firstname)) errors.firstname = 'Must not be empty';
     if (isEmpty(data.lastname)) errors.lastname = 'Must not be empty';
 

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -93,6 +93,7 @@ const Register = () => {
 			errors = {
 				emailError: data.email,
 				usernameError: data.username,
+				passwordError: data.password,
 				confirmPasswordError: data.confirmPassword,
 			};
 			setForm({ ...formState, ...errors });
@@ -209,9 +210,7 @@ const Register = () => {
 												id='password'
 												autoComplete='current-password'
 											/>
-											<FormHelperText color='red'>
-												{passwordError}
-											</FormHelperText>
+											<FormHelperText error>{passwordError}</FormHelperText>
 										</Grid>
 										<Grid item xs={12}>
 											<TextField


### PR DESCRIPTION
API should now send an error if the password is less than 6 characters and if the username contains any whitespace (this includes both spaces and tabs). They should work no problem. Let me know if there are any issues.